### PR TITLE
Echo the generated yarn command when executing

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -24,4 +24,5 @@ if [ ! -z "${workdir}" ] ; then
   fi
 fi
 
+set -x
 yarn ${command} ${options}


### PR DESCRIPTION
I was trying to debug something which turned out to be related the order in which the `${command}` and `${options}` were being appended to `yarn`. Echoing the generated command with `set -x` makes this clearer.