### PR TITLE
Support enabling corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `command` | Specify the command to run with `yarn`. For example `add`. Leave it blank to install dependencies.  |  |  |
 | `args` | Arguments are added to the `yarn` command. You can specify multiple arguments, separated by a space character. For example `react` or `-dev` |  |  |
 | `cache_local_deps` | Select if the contents of node_modules directory should be cached.  `yes`: Mark local dependencies to be cached. `no`: Do not use cache.  All node_modules folders (recursively) located under the working directory will be cached. | required | `no` |
+| `corepack` | Select if corepack should be enabled.  `yes`: Runs `corepack enable`. `no`: Do nothing. | required | `no` |
 | `verbose_log` | Choose if debug logging is enabled.  | required | `no` |
 </details>
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -13,6 +13,7 @@ workflows:
     - COMMAND: install
     - ARGS: -d -ll
     - IS_CACHE: "no"
+    - USE_COREPACK: "no"
     after_run:
     - _run
 
@@ -23,9 +24,22 @@ workflows:
     - COMMAND:
     - ARGS:
     - IS_CACHE: "yes"
+    - USE_COREPACK: "no"
     after_run:
     - _run
     - _check_cache_paths
+
+  # test_yarn_berry:
+  #   envs:
+  #   - TEST_REPO_URL: https://github.com/bitrise-io/sample-apps-yarn-berry.git
+  #   - TEST_REPO_BRANCH: main
+  #   - COMMAND:
+  #   - ARGS:
+  #   - IS_CACHE: "yes"
+  #   - USE_COREPACK: "yes"
+  #   after_run:
+  #   - _run
+  #   - _check_cache_paths
 
   _check_cache_paths:
     steps:
@@ -64,3 +78,4 @@ workflows:
         - command: $COMMAND
         - args: $ARGS
         - cache_local_deps: $IS_CACHE
+        - corepack: $USE_COREPACK

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ type config struct {
 	YarnCommand string `env:"command"`
 	YarnArgs    string `env:"args"`
 	UseCache    bool   `env:"cache_local_deps,opt[yes,no]"`
+	UseCorepack bool   `env:"corepack,opt[yes,no]"`
 	IsDebugLog  bool   `env:"verbose_log,opt[yes,no]"`
 }
 
@@ -57,6 +58,16 @@ func main() {
 		if err := printYarnVersion(absWorkingDir); err != nil {
 			failf("Install dependencies: %s", err)
 		}
+	}
+
+	if (config.UseCorepack) {
+		log.Infof("Enabling corepack...")
+		corepackCmd := command.New("corepack", "enable")
+		out, err := corepackCmd.RunAndReturnTrimmedCombinedOutput()
+		if err != nil {
+			failf("Corepack enable failed: %s, out: %s", err, out)
+		}
+		log.Infof("Enabled corepack.")
 	}
 
 	yarnCmd := command.New("yarn", append(commandParams, args...)...)

--- a/step.yml
+++ b/step.yml
@@ -84,6 +84,18 @@ inputs:
     value_options:
     - "yes"
     - "no"
+- corepack: "no"
+  opts:
+    title: Enable corepack
+    description: |-
+      Select if corepack should be enabled.
+
+      `yes`: Runs `corepack enable`.
+      `no`: Do nothing.
+    is_required: true
+    value_options:
+    - "yes"
+    - "no"
 - verbose_log: "no"
   opts:
     title: Enable verbose logging


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Yarn above version 2 requires corepack to be enabled.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->
Adds `corepack` boolean argument that defaults to false and when set to true will run `corepack enable`

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
- Considered detecting if `packageManager` is set in the `package.json` file and then running `corepack enable` if it is so that no argument is needed. Makes things more straightforward if its an argument.
- There should be a sample repository to test against that uses yarn berry, I presumed you'd want that to be in your GitHub account so left the test commented out

### Decisions

<!-- Please list decisions that were made for this change. -->
Another option is running a script step to enable corepack, but my expectation is that the yarn step sets up yarn